### PR TITLE
Add keyboard dismissal to review textbox

### DIFF
--- a/lib/widgets/dialog/review_dialog.dart
+++ b/lib/widgets/dialog/review_dialog.dart
@@ -24,7 +24,14 @@ class _ReviewDialogState extends State<ReviewDialog> {
     _controller = TextEditingController(text: widget.initialComment);
   }
 
+  // Helper method to dismiss keyboard
+  void _dismissKeyboard() {
+    FocusScope.of(context).unfocus();
+  }
+
   void _onOkPressed() {
+    // Dismiss keyboard before processing
+    _dismissKeyboard();
     final text = _controller.text.trim();
     if (text.isEmpty) {
       setState(() {
@@ -57,32 +64,35 @@ class _ReviewDialogState extends State<ReviewDialog> {
             BoxShadow(color: Colors.black, offset: Offset(2, 2), blurRadius: 0),
           ],
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Title bar
-            Container(
-              color: Colors.deepOrange,
-              padding: EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      'Write/Edit Review',
-                      style: TextStyle(color: Colors.white, fontSize: 12),
+        child: GestureDetector(
+          // Add tap-to-dismiss keyboard functionality
+          onTap: _dismissKeyboard,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Title bar
+              Container(
+                color: Colors.deepOrange,
+                padding: EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Write/Edit Review',
+                        style: TextStyle(color: Colors.white, fontSize: 12),
+                      ),
                     ),
-                  ),
-                  GestureDetector(
-                    onTap: () => Navigator.pop(context),
-                    child: Icon(Icons.close, color: Colors.white, size: 12),
-                  ),
-                ],
+                    GestureDetector(
+                      onTap: () => Navigator.pop(context),
+                      child: Icon(Icons.close, color: Colors.white, size: 12),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            // Content
-            Padding(
-              padding: EdgeInsets.all(8.0),
-              child: Column(
+              // Content
+              Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
@@ -100,6 +110,11 @@ class _ReviewDialogState extends State<ReviewDialog> {
                       controller: _controller,
                       maxLines: 5,
                       style: TextStyle(color: Colors.black),
+                      // Add proper keyboard handling
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (value) {
+                        _dismissKeyboard();
+                      },
                       decoration: InputDecoration(
                         border: InputBorder.none,
                         contentPadding: EdgeInsets.all(8.0),
@@ -165,7 +180,8 @@ class _ReviewDialogState extends State<ReviewDialog> {
                 ],
               ),
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Add keyboard dismissal logic to the `ReviewDialog` to allow users to easily dismiss the keyboard and submit reviews, ensuring consistent behavior across the app.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3afc5bc-78df-4692-8126-f4979e601858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f3afc5bc-78df-4692-8126-f4979e601858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

